### PR TITLE
add version check via global.process 

### DIFF
--- a/lib/check-node.js
+++ b/lib/check-node.js
@@ -2,11 +2,16 @@ const exec = require('child_process').exec
 const semver = require('semver')
 
 module.exports = function (cb) {
-  exec('node --version', (error, stdout, stderr) => {
-    if (error) return (error)
-    var output =  (stdout + stderr).replace(/(\r\n|\n|\r|\ )/gm,"")
-    var sem = semver.valid(output)
+  try {
+    var sem = process.versions.node
     if (sem) return cb(null, sem)
-    cb(null, new Error(output))
-  })
+  } catch (e) {
+    exec('node --version', (error, stdout, stderr) => {
+      if (error) return (error)
+      var output =  (stdout + stderr).replace(/(\r\n|\n|\r|\ )/gm,"")
+      var sem = semver.valid(output)
+      if (sem) return cb(null, sem)
+      cb(null, new Error(output))
+    })
+  }
 }


### PR DESCRIPTION
add version check via global.process which should be supported in recent versions, this can be faster than executing an exec command; falls back to exec if no process.versions.node
