### PR TITLE
Use latest version information if current major ver is unknown

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
                 <div class="card">
                   <div id="current-version">
                     <div class="big-version">Installed: v${version}</div>
-                    <div class="version-desc">There is an updated version of v${semver.major(version)}.</div>
+                    <div class="version-desc">There is an updated version of v${semver.major(latest.version)}.</div>
                     <button class="install" style="margin-top:10px;" nodejs-version="${latest.version}">Update to ${latest.version}</button>
                   </div>
                 </div>

--- a/lib/versions.js
+++ b/lib/versions.js
@@ -42,11 +42,13 @@ Versions.prototype.load = function () {
 Versions.prototype.latest = function (version) {
   if (!version) major = this._latest
   else major = semver.major(version)
+  if (!this.majors[major]) major = this._latest
   return this.majors[major][0]
 }
 Versions.prototype.latestLTS = function (version) {
   if (!version) major = this._latestLTS
   else major = semver.major(version)
+  if (!this.lts[major]) major = this._latestLTS
   return this.lts[major][0]
 }
 


### PR DESCRIPTION
Use the version information for `latest` if the current major version is not known, e.g. because it is test version of one of the io.js releases.
