### PR TITLE
Add Linux support

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -9,16 +9,36 @@ const sudo = require('electron-sudo')
 
 const checkNode = require('./check-node')
 
+function downloadAndInstallInfo () {
+  const base = `https://nodejs.org/dist`
+
+  switch (process.platform) {
+    case 'darwin':
+      return {
+        url: version => `${base}/v${version}/node-v${version}.pkg`,
+        install: path => `installer -pkg ${path} -target /`
+      }
+    case 'linux':
+      return {
+        url: version => `${base}/v${version}/node-v${version}-linux-${process.arch}.tar.gz`,
+        install: path => `tar --strip=1 -C /usr/local -oxf ${path}`
+      }
+  }
+}
+
 module.exports = function install (version, update, cb) {
-  // TODO: Support more than just Mac
+  // TODO: Support more than just Mac and Linux
   version = semver.valid(version)
   cb = once(cb)
-  var u = `https://nodejs.org/dist/v${version}/node-v${version}.pkg`
-  var p = path.join(osenv.tmpdir(), `node-v${version}.pkg`)
+  var info = downloadAndInstallInfo()
+  var u = info.url(version)
+  var filename = path.basename(u)
+  var p = path.join(osenv.tmpdir(), filename)
   console.log(u, p)
   var file = fs.createWriteStream(p)
   request(u).on('error', cb).pipe(file).on('close', () => {
-    var cwd = `installer -pkg ${p} -target /`
+
+    var command = info.install(p)
 
     var sudoOpts = {
       name: `Install Node`,
@@ -31,7 +51,7 @@ module.exports = function install (version, update, cb) {
       }
     }
     update()
-    sudo.exec(cwd, sudoOpts, (err) => {
+    sudo.exec(command, sudoOpts, (err) => {
       if (err) return cb(err)
       checkNode(cb)
     })


### PR DESCRIPTION
Add download URLs + extract command for Linux. This should work
with both GNU `tar` and the BSD `tar`.

Fixes: https://github.com/nodejs/installer/issues/2
