### PR TITLE
Add pack and dist tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist/

--- a/index.html
+++ b/index.html
@@ -71,8 +71,9 @@
         check((err, version) => {
           if (version) {
             var latest = versions.latest(version)
+            let el
             if (semver.eq(latest.version, version)) {
-              var el = yo`
+              el = yo`
               <div class="item">
                 <div class="card">
                   <div id="current-version">
@@ -82,7 +83,7 @@
                 </div>
               </div>`
             } else {
-              var el = yo`
+              el = yo`
               <div class="item">
                 <div class="card">
                   <div id="current-version">
@@ -93,12 +94,12 @@
                 </div>
               </div>`
             }
+            mainElement.appendChild(el)
           }
-          mainElement.appendChild(el)
 
           var stable = versions.latestLTS()
           console.log(stable)
-          var el = yo`
+          let el = yo`
           <div class="item">
             <div class="card">
               <div id="current-version">
@@ -110,7 +111,7 @@
           mainElement.appendChild(el)
 
           var current = versions.latest()
-          var el = yo`
+          el = yo`
           <div class="item">
             <div class="card">
               <div id="current-version">

--- a/package.json
+++ b/package.json
@@ -12,12 +12,18 @@
     "yo-yo": "^1.2.2"
   },
   "devDependencies": {
+    "electron-builder": "^5.10.5",
     "electron-prebuilt": "^1.2.5"
   },
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "pack": "build --dir",
+    "dist": "build"
   },
   "keywords": [],
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (http://www.mikealrogers.com)",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "build": {
+    "appId": "org.nodejs.installer"
+  }
 }


### PR DESCRIPTION
Icons are not added, I don't have assets (please see [step 3](https://github.com/electron-userland/electron-builder#configuration)).

During test, I have discovered issue — NPE if no installed node. 

And currently, packed app cannot find installed node on MacOS because `PATH` is completely different for app (it is not the same as for CLI app). I will file issue about it. On Linux and Windows installed note detected correctly (yeah, MacOS :().
- `npm run pack` will create packed app for current platform and arch.
- `npm run dist` will pack app into distributable format for current platform and arch (e.g. DMG).
- To explicitly set arch or platform: `npm run dist -- -l` (after `--` any electron-builder [args](https://github.com/electron-userland/electron-builder#cli-usage), here `-l` means build for Linux)
- Please see [Multi Platform Build](https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build). As there are no native deps — on MacOS you can build for any platform.
