### PR TITLE
Updated install function

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -70,7 +70,7 @@ function installEvent (e) {
     installing.start()
     // gets version number from button text
     const version = this.children[1].innerHTML.slice(1)
-    installNode(version, () => {}, (err, v) => {
+    installNode(version, (err, v) => {
       if (err) {
         console.log(err)
         domElement('#installing .error-message').style.display = 'block'

--- a/lib/check-node.js
+++ b/lib/check-node.js
@@ -3,10 +3,10 @@ const semver = require('semver')
 
 module.exports = (cb) => {
   exec('node --version', (error, stdout, stderr) => {
-    if (error) return cb(error)
+    if (error) return cb(error, null)
     const output = (stdout + stderr).replace(/(\r\n|\n|\r| )/gm, '')
     const sem = semver.valid(output)
     if (sem) return cb(null, sem)
-    cb(null, new Error(output))
+    cb(new Error(output), null)
   })
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -30,7 +30,7 @@ function downloadAndInstallInfo () {
   }
 }
 
-module.exports = function install (version, update, cb) {
+module.exports = function install (version, cb) {
   version = semver.valid(version)
   cb = once(cb)
   const info = downloadAndInstallInfo()
@@ -52,9 +52,8 @@ module.exports = function install (version, update, cb) {
         }
       }
     }
-    update()
     sudo.exec(command, sudoOpts, (err) => {
-      if (err) return cb(err)
+      if (err) return cb(err, null)
       checkNode(cb)
     })
   })


### PR DESCRIPTION
I have updated the `install` function removing the `update` parameter, because the new UI manages in a different way the refresh after the installation and because in my opinion `install` should only do his job, everything else can be done in the callback.

I also updated the callback inside `check-node.js`, because was passing the error as second argument.
