### PR TITLE
Use ES6 arrow functions more

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -17,11 +17,11 @@ const major = v => v.split('.')[0]
 
 const installing = {
   run: false,
-  start: function () {
+  start() {
     domElement('#installing').style.display = 'block'
     this.run = true
   },
-  done: function () {
+  done() {
     domElement('#installing').style.display = 'none'
     this.run = false
   }

--- a/lib/examples.js
+++ b/lib/examples.js
@@ -41,7 +41,7 @@ fs.readFile(file, function (err, contents) {
 })
 `}]
 
-module.exports = function (callback) {
+module.exports = (callback) => {
   const { title, code } = examples[Math.floor(Math.random() * examples.length)]
   callback(title, code)
 }

--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ function createWindow () {
   mainWindow.webContents.openDevTools()
 
   // Emitted when the window is closed.
-  mainWindow.on('closed', function () {
+  mainWindow.on('closed', () => {
     // Dereference the window object, usually you would store windows
     // in an array if your app supports multi windows, this is the time
     // when you should delete the corresponding element.
@@ -37,7 +37,7 @@ function createWindow () {
 app.on('ready', createWindow)
 
 // Quit when all windows are closed.
-app.on('window-all-closed', function () {
+app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
@@ -45,7 +45,7 @@ app.on('window-all-closed', function () {
   }
 })
 
-app.on('activate', function () {
+app.on('activate', () => {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {


### PR DESCRIPTION
Considering the installer is already ES6-friendly, let's get it to the higher level.

**Note:** It seems that using `() =>` syntax in `version.js` throws a type-related error (LTS and stable version aren't defined due to the error), so I avoided arrow functions there.
