### PR TITLE
Added error-report button

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -7,6 +7,7 @@ const getInstalledVersion = require('./lib/check-node')
 const loadVersions = require('./lib/load.js')
 const installNode = require('./lib/install')
 const getExample = require('./lib/examples')
+const { clipboard, shell } = require('electron')
 
 // utility
 const errIcon = '<i class="fa fa-exclamation-triangle"></i>'
@@ -103,3 +104,14 @@ getExample((title, code) => {
 })
 
 domElement('#error-button').addEventListener('click', installErrorEvent)
+
+function copyErrorInClipboard (e) {
+  e.preventDefault()
+  clipboard.writeText(domElement('#error-text').innerText)
+}
+
+domElement('#error-text').addEventListener('click', copyErrorInClipboard)
+domElement('#error-report').addEventListener('click', function (e) {
+  copyErrorInClipboard(e)
+  shell.openExternal('https://github.com/nodejs/installer/issues/new')
+})

--- a/index.html
+++ b/index.html
@@ -73,6 +73,8 @@
       </div>
       <div class="col-xs-offset-3 col-xs-6 error-message">
           <p id="error-text" class="color-red"></p>
+          <p id="error-report"><a href="#" class="color-red" style="text-decoration: underline;">Report</a></p>
+
           <a id="error-button" href="#" class="color-red">Return to installer</a>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -184,6 +184,7 @@ pre[class*="language-"] {
   font-size: 1.2em;
   margin: 0;
   padding: 0;
+  cursor: pointer;
 }
 
 #error-button {


### PR DESCRIPTION
As titled and discussed in #30.

Bonus, when clicking on `Report` the error message will be automatically copied into the clipboard :)

If you want to try it, just do

``` javascript
cb(new Error('error message'), null)
```

[here](https://github.com/delvedor/installer/blob/7c77486456b75e3269d882df958653ccf5c4aef1/lib/install.js#L33)!
