### PR TITLE
Common main process scaffolding

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,8 +1,8 @@
-const electron = require('electron')
-// Module to control application life.
-const app = electron.app
-// Module to create native browser window.
-const BrowserWindow = electron.BrowserWindow
+const { app, BrowserWindow } = require('electron')
+
+// If the executing binary is named `electron`, we're running
+// in developer mode - otherwise, it'd be `installer`.
+const isDevMode = process.execPath.match(/[\\/]electron/)
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
@@ -18,6 +18,10 @@ function createWindow () {
 
   // and load the index.html of the app.
   mainWindow.loadURL(`file://${__dirname}/../renderer/index.html`)
+  // Open the DevTools, if we're in developer mode
+  if (isDevMode) {
+    mainWindow.webContents.openDevTools()
+  }
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools()

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -21,6 +21,9 @@ function createWindow () {
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools()
+  // Chromium drag and drop events tend to navigate the app away, making the
+  // app impossible to use without restarting. These events should be prevented.
+  mainWindow.webContents.on('will-navigate', (event) => event.preventDefault())
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -8,32 +8,33 @@ const isDevMode = process.execPath.match(/[\\/]electron/)
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
 
+/**
+ * This is the main method executed in the main process.
+ */
 function createWindow () {
-  // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1000,
     height: 700,
-    resizable: false
+    resizable: false,
+    show: false
   })
 
-  // and load the index.html of the app.
+  // Load the index.html of the app. Once loaded, we'll display
+  // the window.
   mainWindow.loadURL(`file://${__dirname}/../renderer/index.html`)
+  mainWindow.webContents.on('did-finish-load', () => mainWindow.show())
+
   // Open the DevTools, if we're in developer mode
   if (isDevMode) {
     mainWindow.webContents.openDevTools()
   }
 
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools()
   // Chromium drag and drop events tend to navigate the app away, making the
   // app impossible to use without restarting. These events should be prevented.
   mainWindow.webContents.on('will-navigate', (event) => event.preventDefault())
 
   // Emitted when the window is closed.
   mainWindow.on('closed', () => {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
     mainWindow = null
   })
 }
@@ -59,6 +60,3 @@ app.on('activate', () => {
     createWindow()
   }
 })
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.


### PR DESCRIPTION
This PR is pretty small and contains three changes, bundled together only because they're each so small:

- Dragging a file into the window would normally instruct Electron to navigate _to_ the file. In general, navigation is a bad idea. I disabled it.
- Developer Tools were configured to open no matter what, which seems bad. Instead, I'm only opening them when we're actually a developer (which we can determine by looking at the process name).
- The window was first opened and the content then loaded. This leads to a white "flash" of a few ms, but can be avoided by loading before the window is shown.

Closes #41 
Closes #40 
Closes #39