### PR TITLE
deps: add electron-forge as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "yo-yo": "^1.2.2"
   },
   "devDependencies": {
+    "electron-forge": "^3.0.5",
     "electron-prebuilt-compile": "1.6.11",
     "standard": "^7.1.2"
   }


### PR DESCRIPTION
This seems to be required to run `npm start`.