### PR TITLE
Enable JS passthrough and a nicer productName

### DIFF
--- a/.compilerc
+++ b/.compilerc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "development": {
+      "application/javascript": {
+        "passthrough": true
+      }
+    },
+    "production": {
+      "application/javascript": {
+        "passthrough": true
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist/
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "installer",
   "version": "0.1.0",
-  "productName": "node-installer",
+  "productName": "Node.js Installer",
   "description": "An Electron application for installing, updating and managing versions of Node.js.",
   "main": "src/main/main.js",
   "scripts": {


### PR DESCRIPTION
Just a few small things to make the dev flow a bit nicer out of the gate.

* Adds a custom `.compilerc` to enable JS passthrough so we aren't piping code through babel when we don't need to.  If we want typescript / babel in the future that can be discussed in #47 
* Adds `.vscode` to gitignore
* Sets the `productName` to be the more human readable "Node.js Installer"