### PR TITLE
Add the packaging metadata to build the node snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,26 @@
+name: node
+version: v8.5.0
+summary: Node.js JavaScript runtime
+description: |
+  Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+  Node.js uses an event-driven, non-blocking I/O model that makes it
+  lightweight and efficient. The Node.js package ecosystem, npm, is the
+  largest ecosystem of open source libraries in the world.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+
+apps:
+  node:
+    command: bin/node
+  npm:
+    command: bin/npm
+
+parts:
+  node:
+    source: https://github.com/nodejs/node.git
+    source-tag: v8.5.0
+    plugin: autotools
+    build-packages: [g++, clang, python]
+    organize:
+      usr/local: .


### PR DESCRIPTION
This package will let you publish the latest nodejs in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.